### PR TITLE
Make images responsive

### DIFF
--- a/_sass/SHB_css.scss
+++ b/_sass/SHB_css.scss
@@ -124,6 +124,8 @@ a:focus,
 
 img {
   border-radius: 5%;
+  max-width: 100%;
+  height: auto;
 }
 
 .btn {


### PR DESCRIPTION
Add max-width: 100% and height: auto to the img rule so images scale to their containers and avoid overflow while retaining the existing border-radius styling.